### PR TITLE
Fixed html escaping so that it uses Strings::to_html

### DIFF
--- a/pages/_contents-page.xnode
+++ b/pages/_contents-page.xnode
@@ -12,7 +12,7 @@
 
 		?>
 		<div class="table-of-contents">
-			<h4>#{(attributes['title'] || "Table Of Contents").to_html}</h4>
+			<h4>#{Strings::to_html(attributes['title'] || "Table Of Contents")}</h4>
 			<ol>
 			<?r (prev_links || []).each do |link| ?>
 				<li>#{link.to_href}</li>

--- a/pages/_listing.xnode
+++ b/pages/_listing.xnode
@@ -1,7 +1,7 @@
 <?r 
 if attributes['src']
-	path = parent.node.local_path(Path.create(attributes['src']))
-	escaped_code = File.read(path).to_html
+	path = parent.node.local_path(Utopia::Path.create(attributes['src']))
+	escaped_code = Strings::to_html(File.read(path))
 else
 	escaped_code = content
 end


### PR DESCRIPTION
I'm guessing there is a reason why Trenni doesn't extend the String class.
